### PR TITLE
Add word art standalone demo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "emoji-selector": "notwaldorf/emoji-selector#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.21",
-    "carbon-route": "polymerelements/carbon-route#^0.8.4",
+    "app-route": "polymerelements/app-route#^0.8.4",
     "paper-icon-button": "polymerelements/paper-icon-button#^1.0.0"
   },
   "devDependencies": {

--- a/client/components.html
+++ b/client/components.html
@@ -1,8 +1,8 @@
-<base href="https://polygit2.appspot.com/emoji-selector+notwaldorf+:master/emojilib+muan+1.0.1/components/">
+<base href="https://polygit2.appspot.com/emoji-selector+notwaldorf+:master/components/">
 
 <!-- <link rel="import" href="emoji-selector/emoji-selector.html"> -->
-<link rel="import" href="carbon-route/carbon-location.html">
-<link rel="import" href="carbon-route/carbon-route.html">
+<link rel="import" href="app-route/app-location.html">
+<link rel="import" href="app-route/app-route.html">
 <link rel="import" href="font-roboto/roboto.html">
 
 <link rel="import" href="iron-ajax/iron-ajax.html">

--- a/client/elements/emoji-selector.html
+++ b/client/elements/emoji-selector.html
@@ -1,3 +1,5 @@
+<base href="https://polygit2.appspot.com/emojilib+muan+1.0.1/components/">
+
 <dom-module id="emoji-selector">
   <template>
     <style>
@@ -56,7 +58,7 @@
         background-color: var(--emoji-selector-highlight, --paper-teal-50);
       }
     </style>
-    <iron-ajax url="../bower_components/emojilib/emojis.json" last-response="{{emojilib}}" auto></iron-ajax>
+    <iron-ajax url="emojilib/emojis.json" last-response="{{emojilib}}" auto></iron-ajax>
     <section class="navigation">
       <paper-input label="Filter" id="search" value="{{filter}}"></paper-input>
       <paper-tabs selected="{{category}}" id="tabs" tabindex="0">

--- a/client/elements/emoji-word-art-app.html
+++ b/client/elements/emoji-word-art-app.html
@@ -4,18 +4,18 @@
 <link rel="import" href="./word-art.html">
 <dom-module id="emoji-word-art-app">
   <template>
-    <carbon-location route="{{route}}" use-hash-as-path></carbon-location>
-    <carbon-route
+    <app-location route="{{route}}" use-hash-as-path></app-location>
+    <app-route
         route="[[route]]"
         pattern="/:action"
         data="{{actionData}}"
         tail="{{actionRoute}}">
-    </carbon-route>
-    <carbon-route
+    </app-route>
+    <app-route
         route="[[actionRoute]]"
         data="{{idData}}"
         pattern="/:id">
-    </carbon-route>
+    </app-route>
     <iron-pages
         selected="{{actionData.action}}"
         attr-for-selected="id">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+    <title>Emoji Word Art</title>
+    <link rel="import" href="client/components.html">
+    <link rel="import" href="client/elements/word-art.html">
+    <link rel="import" href="client/elements/emoji-picker.html">
+
+    <style is="custom-style">
+      body {
+        margin: 0;
+        padding: 0;
+        display: block;
+        position: relative;
+        width: 100vw;
+        height: 100vh;
+        background-attachment: fixed;
+        background-image: linear-gradient(
+            145deg,
+            #F18D60 0%,
+            #F18D60 50%,
+            #F17960 50%,
+            #F17960 55%,
+            #F16560 55%,
+            #F16560 60%,
+            #F15160 60%,
+            #F15160 65%,
+            #F13D60 65%,
+            #F13D60 100%);
+        @apply(--layout-vertical);
+        @apply(--layout-center-center);
+      }
+
+      section {
+        background-color: rgba(255, 255, 255, 0.2);
+        padding: 1em;
+        border-radius: 2px;
+
+        @apply(--layout-horizontal);
+        @apply(--layout-wrap);
+        @apply(--layout-center-center);
+      }
+
+      paper-input {
+        margin: 1em;
+        --paper-input-container-color: white;
+        --paper-input-container-input-color: white;
+        --paper-input-container-input: {
+          font-size: 40px;
+        }
+      }
+    </style>
+  </head>
+  <body unresolved>
+    <template is="dom-bind" id="t">
+      <section class="inputs">
+        <emoji-picker selected-emoji="{{foreground}}"></emoji-picker>
+        <emoji-picker selected-emoji="{{background}}"></emoji-picker>
+        <paper-input
+            placeholder="Best words go here"
+            no-label-float
+            value="{{text}}">
+        </paper-input>
+      </section>
+
+      <word-art
+          foreground="{{foreground}}"
+          background="{{background}}"
+          text="{{text}}">
+      </word-art>
+    </template>
+  </body>
+  <script>
+    t.foreground = '👻';
+    t.background = '🍋';
+    t.text = 'hai';
+  </script>
+</html>


### PR DESCRIPTION
Because of polygit and friends magic, I think `/index.html` works as a standalone (sans `bower_components`) -- I've been testing it on a simple python server, without a `bower install`. So if you just push `master` to `gh-pages` this should appear at http://cdata.github.io/data-pipe-elements? I think.

Edit: yeah, it does. http://notwaldorf.github.io/data-pipe-elements/ works.

🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂
🎂🎉🎉🎂🎂🎉🎉🎂🎂🎂🎉🎉🎉🎉🎂🎂🎂🎉🎉🎂🎂🎉🎉🎂
🎂🎂🎉🎉🎉🎉🎂🎂🎂🎉🎉🎂🎂🎉🎉🎂🎂🎂🎉🎉🎉🎉🎂🎂
🎂🎂🎂🎉🎉🎂🎂🎂🎂🎉🎉🎉🎉🎉🎉🎂🎂🎂🎂🎉🎉🎂🎂🎂
🎂🎂🎂🎉🎉🎂🎂🎂🎂🎉🎉🎂🎂🎉🎉🎂🎂🎂🎂🎉🎉🎂🎂🎂
🎂🎂🎂🎉🎉🎂🎂🎂🎂🎉🎉🎂🎂🎉🎉🎂🎂🎂🎂🎉🎉🎂🎂🎂
🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂🎂
